### PR TITLE
Add title character limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains all the peer-to-peer (🍐-to-🍐) commons specificati
 
 | Specification | Version |
 | --- | --- |
-| [Module](./module.md) | `v0.2.0` |
+| [Module](./module.md) | `v0.2.1` |
 | [Interoperability](./interoperability.md) | `v0.2.1` | 
 
 ## Contributors ✨

--- a/module.md
+++ b/module.md
@@ -107,7 +107,7 @@ conditions are specified per name.
 | `p2pcommons.contents` | array of strings | [`^(dat:\/\/)?(\w{64})(\+\d+)?$`](https://regex101.com/r/naEFVg/4)                                  |
 
 `title` and `description` MUST be strings. `title` MUST contain a
-string and `description` MAY be empty (`''`; see also
+string (max character length 300) and `description` MAY be empty (`''`; see also
 [Registration](#registration)).
 
 `url` MUST be a string containing the non-versioned Dat archive key

--- a/module.md
+++ b/module.md
@@ -1,4 +1,4 @@
-# Module specifications v0.2.0
+# Module specifications v0.2.1
 
 This document outlines specifications for module initialization,
 validation, registration, and verification on the Dat network. It is a
@@ -12,7 +12,7 @@ types.
 
 This specification is versioned using [Semantic Versioning
 2.0.0](https://semver.org/); `{MAJOR}.{MINOR}.{PATCH}` and is now at
-`v0.2.0`. This specification formulates bare minimum specifications to
+`v0.2.1`. This specification formulates bare minimum specifications to
 reduce the risk of major, backwards incompatible changes. Please note
 that this specification is downstream from the [Dat
 protocol](https://www.datprotocol.com/).


### PR DESCRIPTION
As discussed in the [`@p2pcommons/working-group`](https://github.com/p2pcommons/working-group) of 2019-12-10, hereby making an addition for a character limit to the module specification.

The limit is set to 300 characters right now, which is based on a sampling of CrossRef. The results of the ~1000 sampled titles from scholarly publications in 2019 (out of [3,715,092](http://api.crossref.org/works?filter=from-pub-date:2019,until-pub-date:2019,type:journal-article&rows=0)) resulted in: 

|      99% |   99.9% |   99.99% |
| -- | --| --| 
| 206.0100 | 280.0770 | 349.3077 |

This means that 300 characters gives us a coverage of an estimated 99.9%. R code included below.

PS: For those interested, the 300 comes from the 99.9P of an earlier run that didn't make explicity we only wanted titles from journal articles. I already made the edit and then reran, which resulted in these data.

```R
sample = 100                            # max 100 for CR API
url = sprintf('https://api.crossref.org/works?filter=from-pub-date:2019,until-pub-date:2019,type:journal-article&sample=%s', sample)

obj <- c()
i <- 0
while (i < 10) {
  call <- httr::GET(url)
  res <- httr::content(call)
  x <- unlist(res)
  x[names(x) == "message.items.title"]

  y = x[names(x) == "message.items.title"]

  obj <- c(obj, stringr::str_length(y))

  cat(sprintf('Just completed %s\n', i))
  i = i + 1
}

quantile(obj, c(.99, .999, .9999))
```
