### PR TITLE
Add `p2pcommons.avatar` proposal

### DIFF
--- a/module.md
+++ b/module.md
@@ -1,4 +1,4 @@
-# Module specifications v0.2.1
+# Module specifications v0.2.2
 
 This document outlines specifications for module initialization,
 validation, registration, and verification on the Dat network. It is a
@@ -12,7 +12,7 @@ types.
 
 This specification is versioned using [Semantic Versioning
 2.0.0](https://semver.org/); `{MAJOR}.{MINOR}.{PATCH}` and is now at
-`v0.2.1`. This specification formulates bare minimum specifications to
+`v0.2.2`. This specification formulates bare minimum specifications to
 reduce the risk of major, backwards incompatible changes. Please note
 that this specification is downstream from the [Dat
 protocol](https://www.datprotocol.com/).
@@ -76,7 +76,7 @@ specification](https://html.spec.whatwg.org/multipage/semantics.html#the-link-el
 `main`. If `p2pcommons.type: content`, the object MUST include the
 key/value pairs `authors` and `parents`. If `p2pcommons.type:
 profile`, the object MUST include the key/value pairs `follows` and
-`contents`.
+`contents`. It is RECOMMENDED to include the `p2pcommons.avatar` key/value pair.
 
 For legibility and consistency across implementations, the ordering of
 the key/value is RECOMMENDED to be in the order presented in the
@@ -101,6 +101,7 @@ conditions are specified per name.
 | `p2pcommons.type`     | string           | [`(profile OR content)$`](https://regex101.com/r/RRKb5N/1)                                          |
 | `p2pcommons.subtype`  | string           | [`^\w+$`](https://regex101.com/r/hDRGfc/1)                                                            |
 | `p2pcommons.main`     | string           | [`^((?!\/) OR (\.\/))(?!~ OR \.).*(?<!\/)$`](https://regex101.com/r/MZXJnK/1)                       |
+| `p2pcommons.avatar`     | string           | [`^((?!\/) OR (\.\/))(?!~ OR \.).*(?<!\/)$`](https://regex101.com/r/MZXJnK/1)                       |
 | `p2pcommons.authors`  | array of strings | [`^(dat:\/\/)?(\w{64})$`](https://regex101.com/r/naEFVg/2)                                          |
 | `p2pcommons.parents`  | array of strings | [`^(dat:\/\/)?(\w{64})(\+\d+)$`](https://regex101.com/r/naEFVg/3)                                   |
 | `p2pcommons.follows`  | array of strings | [`^(dat:\/\/)?(\w{64})(\+\d+)?$`](https://regex101.com/r/naEFVg/4)                                  |
@@ -139,6 +140,12 @@ this -->
 `p2pcommons.main` MUST be a string containing one relative path but MUST
 NOT refer to a relative home or relative parent directory. The
 relative path SHOULD refer to a valid relative file within the Dat
+archive (see also [Registration](#registration)). The `./` part of a
+relative path MAY be included.
+
+If included, `p2pcommons.avatar` MUST be a string containing one relative path but MUST
+NOT refer to a relative home or relative parent directory. The
+relative path SHOULD refer to a valid relative image file within the Dat
 archive (see also [Registration](#registration)). The `./` part of a
 relative path MAY be included.
 

--- a/module.md
+++ b/module.md
@@ -143,7 +143,7 @@ relative path SHOULD refer to a valid relative file within the Dat
 archive (see also [Registration](#registration)). The `./` part of a
 relative path MAY be included.
 
-If included, `p2pcommons.avatar` MUST be a string containing one relative path but MUST
+If included, `p2pcommons.avatar` MUST be a string containing one relative path not pointing outside the module folder
 NOT refer to a relative home or relative parent directory. The
 relative path SHOULD refer to a valid image file within the Dat
 archive (see also [Registration](#registration)). The `./` part of a

--- a/module.md
+++ b/module.md
@@ -145,7 +145,7 @@ relative path MAY be included.
 
 If included, `p2pcommons.avatar` MUST be a string containing one relative path but MUST
 NOT refer to a relative home or relative parent directory. The
-relative path SHOULD refer to a valid relative image file within the Dat
+relative path SHOULD refer to a valid image file within the Dat
 archive (see also [Registration](#registration)). The `./` part of a
 relative path MAY be included.
 

--- a/module.md
+++ b/module.md
@@ -76,7 +76,7 @@ specification](https://html.spec.whatwg.org/multipage/semantics.html#the-link-el
 `main`. If `p2pcommons.type: content`, the object MUST include the
 key/value pairs `authors` and `parents`. If `p2pcommons.type:
 profile`, the object MUST include the key/value pairs `follows` and
-`contents`. It is RECOMMENDED to include the `p2pcommons.avatar` key/value pair.
+`contents`; it is RECOMMENDED to include the `p2pcommons.avatar` key/value pair for profiles.
 
 For legibility and consistency across implementations, the ordering of
 the key/value is RECOMMENDED to be in the order presented in the
@@ -125,7 +125,7 @@ https://beakerbrowser.com/docs/apis/manifest.html -->
 
 `links.spec` MUST contain an object in an array with key/value pair
 `href` referring to the active module specification URL (e.g.,
-`https://p2pcommons.com/specs/module/0.2.0`).
+`https://p2pcommons.com/specs/module/0.2.2`).
 
 `p2pcommons.type` MUST be a string containing either `content` or
 `profile`.
@@ -143,8 +143,7 @@ relative path SHOULD refer to a valid relative file within the Dat
 archive (see also [Registration](#registration)). The `./` part of a
 relative path MAY be included.
 
-If included, `p2pcommons.avatar` MUST be a string containing one relative path not pointing outside the module folder
-NOT refer to a relative home or relative parent directory. The
+If included, `p2pcommons.avatar` MUST be a string containing one relative path that MUST NOT refer to a relative home or relative parent directory. The
 relative path SHOULD refer to a valid image file within the Dat
 archive (see also [Registration](#registration)). The `./` part of a
 relative path MAY be included.
@@ -235,7 +234,7 @@ The links used in the examples do not work and serve illustrative purposes only.
   "url": "00a4f2f18bb6cb4e9ba7c2c047c8560d34047457500e415d535de0526c6b4f23",
   "links": {
      "license": [{"href": "https://creativecommons.org/publicdomain/zero/1.0/legalcode"}],
-     "spec": [{"href": "https://p2pcommons/specs/module/0.2.0"}]
+     "spec": [{"href": "https://p2pcommons/specs/module/0.2.2"}]
   },
   "p2pcommons": {
     "type": "content",
@@ -262,12 +261,13 @@ The links used in the examples do not work and serve illustrative purposes only.
   "url": "cca6eb69a3ad6104ca31b9fee7832d74068db16ef2169eaaab5b48096e128342",
   "links": {
      "license": [{"href": "https://creativecommons.org/publicdomain/zero/1.0/legalcode"}],
-     "spec": [{"href": "https://p2pcommons/specs/module/0.2.0"}]
+     "spec": [{"href": "https://p2pcommons/specs/module/0.2.2"}]
   },
   "p2pcommons": {
     "type": "profile",
     "subtype": "",
     "main": "test-profile.html",
+    "avatar": "./test.png",
     "follows": [
       "f7daadc2d624df738abbccc9955714d94cef656406f2a850bfc499c2080627d4"
     ],


### PR DESCRIPTION
This commit introduces an avatar key/value for the p2pcommons. This helps visual display of modules, both for `content` and `profile` types.

Remaining questions from my side prior to merge:

- [x] Do we need to set a file limitation? If so, which? Maybe simply `.jpeg`, `.jpg`, and `.png`?
- [x] Should we include a file size limitation/recommendation?