### PR TITLE
Update to v0.3.0

### DIFF
--- a/module.md
+++ b/module.md
@@ -230,7 +230,7 @@ All files in a module MUST be of an [open file format](https://en.wikipedia.org/
 
 In case of text based files, we RECOMMEND Hypertext Markup Language (HTML) files. In case of multiple versions of the same text file, the HTML version SHOULD be preferred as the main file.
 
-In order to remain self-contained, all files SHOULD reference information from valid relative paths within the module itself as much as possible. Absolute filepaths MUST NOT be used to load information.
+In order to remain self-contained, all references to local files SHOULD be valid relative file paths within the module itself. Files MAY reference URLs. It is RECOMMENDED to use references to module files instead of URLs as much as possible. Where URLs cannot be avoided, it is RECOMMENDED to use [persistent URLs](https://en.wikipedia.org/wiki/Persistent_uniform_resource_locator) as much as possible.
 
 ## Examples
 

--- a/module.md
+++ b/module.md
@@ -1,7 +1,7 @@
-# Module specifications v0.2.7
+# Module specifications v0.3.0
 
-This document outlines specifications for module initialization,
-validation, registration, and verification on the Dat network. It is a
+This document outlines specifications for module [initialization](#initialization),
+[metadata validation](#metadata), [registration](#registration), [verification](#verification), and for [module files](#files). It is a
 derivative of previous peer-reviewed publications
 [[1](https://doi.org/10.3390/publications6020021),
 [2](https://doi.org/10.3390/publications7020040)] that may be
@@ -11,9 +11,9 @@ This specification assumes a JavaScript environment in describing
 types.
 
 This specification is versioned using [Semantic Versioning
-2.0.0](https://semver.org/); `{MAJOR}.{MINOR}.{PATCH}` and is now at
-`v0.2.7`. This specification formulates bare minimum specifications to
-reduce the risk of major, backwards incompatible changes. Please note
+2.0.0](https://semver.org/); `{MAJOR}.{MINOR}.{PATCH}`. This 
+specification formulates bare minimum specifications to reduce the
+risk of major, backwards incompatible changes. Please note
 that this specification is downstream from the [Dat
 protocol](https://www.datprotocol.com/).
 
@@ -224,6 +224,14 @@ later on, so I erred on the side of strictness and parsimony -->
 <!-- + I am being non-specific about Dat protocol requirements to
 allow for flexibility down the line? I mean, I -->
 
+## Files
+
+All files in a module MUST be of an [open file format](https://en.wikipedia.org/wiki/List_of_open_formats); these file formats can be used and implemented by anyone. Wikipedia and Wikidata SHOULD be considered the authority in determining what file formats are considered open.
+
+In case of text based files, we RECOMMEND Hypertext Markup Language (HTML) files. In case of multiple versions of the same text file, the HTML version SHOULD be preferred as the main file.
+
+In order to remain self-contained, all files SHOULD reference information from valid relative paths within the module itself as much as possible. Absolute filepaths MUST NOT be used to load information.
+
 ## Examples
 
 The links used in the examples do not work and serve illustrative purposes only.
@@ -237,7 +245,7 @@ The links used in the examples do not work and serve illustrative purposes only.
   "url": "hyper://00a4f2f18bb6cb4e9ba7c2c047c8560d34047457500e415d535de0526c6b4f23",
   "links": {
      "license": [{"href": "https://creativecommons.org/publicdomain/zero/1.0/legalcode"}],
-     "spec": [{"href": "https://p2pcommons/specs/module/0.0.0"}]
+     "spec": [{"href": "https://p2pcommons.com/specs/module/0.0.0"}]
   },
   "p2pcommons": {
     "type": "content",
@@ -264,7 +272,7 @@ The links used in the examples do not work and serve illustrative purposes only.
   "url": "hyper://cca6eb69a3ad6104ca31b9fee7832d74068db16ef2169eaaab5b48096e128342",
   "links": {
      "license": [{"href": "https://creativecommons.org/publicdomain/zero/1.0/legalcode"}],
-     "spec": [{"href": "https://p2pcommons/specs/module/0.0.0"}]
+     "spec": [{"href": "https://p2pcommons.com/specs/module/0.0.0"}]
   },
   "p2pcommons": {
     "type": "profile",


### PR DESCRIPTION
This commit includes a proposal for the files specification. 

I posted some of the discussion I had with @jameslibscie in the ☕ chat:
> The proposal will be a bit different and simply a file spec as part of the larger module spec. It's a tad too difficult to make a text spec that differentiates between main and non-main files, because we have content types that create ambiguity in decision rules about potential text specs. 
> For example: A module of content type "Presentation" might reasonably include a PDF file as the main file; if we have a PDF file for content type "Theory", we would not want that because it's text and the PDF locks it up a bit. However, if we set that rule, we would have to start curating rules for each content type, which quickly grows in amount of work. Plus, this might be more of an implementation question than for the specs. 
> In other words, our file specification will replace the text specification and imply a lot of these preferences but not mandate them.

By now simply stating that we want module files to be open file formats, and include a recommendation for HTML where possible, we start nudging towards it. We can include more UX nudges in Hypergraph directly, making HTML more attractive down the line. This would mean that we might need to do more processing of various files when we start our text-mining processes.

It also corrects a few minor issues in the examples and cleans up the references to the version number. Now only the title needs to be adjusted when the version is bumped.

Note: This PR supercedes #17 