### PR TITLE
Add parents condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains all the peer-to-peer (🍐-to-🍐) commons specificati
 
 | Specification | Version |
 | --- | --- |
-| [Module](./module.md) | `v0.3.0` |
+| [Module](./module.md) | `v0.3.1` |
 | [Interoperability](./interoperability.md) | `v0.2.2` | 
 
 ## Contributors ✨

--- a/module.md
+++ b/module.md
@@ -157,7 +157,7 @@ Hyperdrive keys SHOULD each refer to a valid module of
 an array of strings containing unique versioned Hyperdrive keys. These
 versioned Hyperdrive keys SHOULD each refer to a valid module of
 `p2pcommons.type: content` and MUST be registered by at least one of 
-its self-designated authors. If it contains this module's own Hyperdrive
+its listed authors. If it contains this module's own Hyperdrive
 key, it MUST refer to a preceding version.
 <!-- it is RECOMMENDED to only allow verified parents? -->
 

--- a/module.md
+++ b/module.md
@@ -157,7 +157,8 @@ Hyperdrive keys SHOULD each refer to a valid module of
 an array of strings containing unique versioned Hyperdrive keys. These
 versioned Hyperdrive keys MUST each refer to a valid module of
 `p2pcommons.type: content` and MUST be registered by at least one of 
-its listed authors profile at the time this value is set. The network state SHOULD be up-to-date before determining registration status.
+its listed authors' profiles at the time this value is set. The network state
+SHOULD be up-to-date before determining registration status.
 If `p2pcommons.parents` contains this module's own Hyperdrive
 key, it MUST refer to a preceding version.
 <!-- it is RECOMMENDED to only allow verified parents? -->

--- a/module.md
+++ b/module.md
@@ -1,4 +1,4 @@
-# Module specifications v0.3.0
+# Module specifications v0.3.1
 
 This document outlines specifications for module [initialization](#initialization),
 [metadata validation](#metadata), [registration](#registration), [verification](#verification), and for [module files](#files). It is a
@@ -156,7 +156,8 @@ Hyperdrive keys SHOULD each refer to a valid module of
 `p2pcommons.parents` (specific to `p2pcommons.type: content`) MUST be
 an array of strings containing unique versioned Hyperdrive keys. These
 versioned Hyperdrive keys SHOULD each refer to a valid module of
-`p2pcommons.type: content`. If it contains this module's own Hyperdrive
+`p2pcommons.type: content` and MUST be registered by at least one of 
+its self-designated authors. If it contains this module's own Hyperdrive
 key, it MUST refer to a preceding version.
 <!-- it is RECOMMENDED to only allow verified parents? -->
 

--- a/module.md
+++ b/module.md
@@ -1,4 +1,4 @@
-# Module specifications v0.3.1
+# Module specifications v0.3.3
 
 This document outlines specifications for module [initialization](#initialization),
 [metadata validation](#metadata), [registration](#registration), [verification](#verification), and for [module files](#files). It is a
@@ -155,9 +155,10 @@ Hyperdrive keys SHOULD each refer to a valid module of
 
 `p2pcommons.parents` (specific to `p2pcommons.type: content`) MUST be
 an array of strings containing unique versioned Hyperdrive keys. These
-versioned Hyperdrive keys SHOULD each refer to a valid module of
+versioned Hyperdrive keys MUST each refer to a valid module of
 `p2pcommons.type: content` and MUST be registered by at least one of 
-its listed authors. If it contains this module's own Hyperdrive
+its listed authors profile at the time this value is set. The network state SHOULD be up-to-date before determining registration status.
+If `p2pcommons.parents` contains this module's own Hyperdrive
 key, it MUST refer to a preceding version.
 <!-- it is RECOMMENDED to only allow verified parents? -->
 


### PR DESCRIPTION
Based on the discussion in #27 I add the condition that the parent MUST be registered by at least one of its authors. Practically, this will mean that no child modules can be created for "draft" content OR "retracted" content (where all authors remove the content). Unverified content (e.g., three of four authors have removed the content from profile) can still serve as the basis of new work.

This will enforce as-you-go reporting and has the benefit of making retracted work not be the basis of new content. 